### PR TITLE
fix: Gradle build error caused by misplaced curly bracket

### DIFF
--- a/samples/directory-samples-java/auth-samples/build.gradle.kts
+++ b/samples/directory-samples-java/auth-samples/build.gradle.kts
@@ -31,10 +31,11 @@ dependencies {
 
     testImplementation("io.rest-assured:rest-assured:5.2.0")
     testImplementation("io.rest-assured:json-path:5.2.0")
-}
 
     // HAPI FHIR LIBRARIES for Mapping FHIR Resources
     implementation ("ca.uhn.hapi.fhir:hapi-fhir-base:6.10.5")
     implementation ("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.10.5")
+
     // HAPI FHIR Client
     implementation ("ca.uhn.hapi.fhir:hapi-fhir-client:6.10.5")
+}


### PR DESCRIPTION
## Fix Gradle Build Error

### Description
This pull request addresses a build error in the `auth-samples/build.gradle.kts` file.
The error was caused by a misplaced curly bracket in the configuration of the `JavaCompile` task, introduced in https://github.com/gematik/api-vzd/commit/c3dec9c8061352a079e06c7f703d07804bff4c4f.

The curly bracket has been moved to the correct position to ensure the build script is properly formatted and functional.

### Changes
- Corrected the position of the curly bracket in the `auth-samples/build.gradle.kts` file.

### Testing
- Verified that the Gradle build runs successfully after the fix.

### Related Issues
- None

Please review the changes and merge if they look good.