### PR TITLE
Use common action for generating images

### DIFF
--- a/.github/workflows/GeneratePlantumlImages.yml
+++ b/.github/workflows/GeneratePlantumlImages.yml
@@ -2,39 +2,18 @@ name: GeneratePlantumlImages
 
 on:
   push:
-    branches: [ '*' ]
-    paths: [ 'src/plantuml/**' ]
+    branches: [ '**' ]
+    paths: [ '.github/workflows/GeneratePlantumlImages.yml', 'src/plantuml/**', 'images/diagrams/**' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      # Runs a single command using the runners shell
-      - name: Generate images
-        run: |
-          mkdir -p images/diagrams
-          rm -rf images/diagrams/*
-          for fullname in src/plantuml/*.puml
-          do
-            base=$(basename -- "$fullname")
-            echo ${base%.*}
-            curl --silent --show-error --fail -H "Content-Type: text/plain; charset=utf-8" \
-              --data-binary @- https://plantuml.gematik.solutions/plantuml/svg/ \
-              --output - < "src/plantuml/${base%.*}.puml" > "images/diagrams/${base%.*}.svg"
-            curl --silent --show-error --fail -H "Content-Type: text/plain; charset=utf-8" \
-              --data-binary @- https://plantuml.gematik.solutions/plantuml/png/ \
-              --output - < "src/plantuml/${base%.*}.puml" > "images/diagrams/${base%.*}.png"
-          done
-
-
-      - name: Add & Commit
-        uses: EndBug/add-and-commit@v8
-        with:
-          add: 'images/diagrams/'
+    uses: gematik/github-image-actions/.github/workflows/generate-images.yml@0.3.0
+    with:
+      srcdir: src/plantuml
+      outdir: images/diagrams
+      ref: 0.3.0
+      png: true
+      svg: true


### PR DESCRIPTION
Dieses Pull Request wechselt für die Generierung der Bilder auf die entsprechende gematik GitHub Action, die auch in https://github.com/gematik/api-ti-messenger verwendet wird. Soweit ich sehen kann sind die generierten Bilder bis auf leichte Unterschiede in der Schriftart identisch mit der alten Generierungsmethode (siehe [hier](https://github.com/Johennes/api-vzd/pull/1/files)).