### PR TITLE
move GET /localization response object to schemas

### DIFF
--- a/src/openapi/I_VZD_TIM_Provider_Services.yaml
+++ b/src/openapi/I_VZD_TIM_Provider_Services.yaml
@@ -224,15 +224,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                enum: [ org, pract, orgPract, none ]
-                example: org
-                description: |
-                  Returns in which part of the directory the MXID is located:
-                   - org:      Located in the Organization part
-                   - pract:    Located in the Practitioner part
-                   - orgPract: Located in the Organization and Practitioner part
-                   - none:     Not found in any part
+                $ref: "#/components/schemas/MxIdLocation"
         400:
           description: Bad Request
           content:
@@ -595,6 +587,17 @@ components:
           type: string
           description: Die Version von dem OpenAPI Document (YAML Datei)
           example: "1.0.0"
+
+    MxIdLocation:
+      type: string
+      enum: [ org, pract, orgPract, none ]
+      example: org
+      description: |
+        Returns in which part of the directory the MXID is located:
+         - org:      Located in the Organization part
+         - pract:    Located in the Practitioner part
+         - orgPract: Located in the Organization and Practitioner part
+         - none:     Not found in any part
 
   securitySchemes:
     OAuth2:


### PR DESCRIPTION
When generating code from OpenApi spec files some generators cannot handle inline schemas properly. In this specific case the generator I use does not generate an enum as stated in the spec but simply a string. The content-type is defined as json, but generated client methods just return a string, where the Api returns a Json string, (`pract` vs. `"pract"`), which makes it more difficult and error-prone to properly evaluate the Api response. 

Moving the enum to schemas avoids this issue. Please consider accepting this PR.

Kind regards, 
Martin