### PR TITLE
chore: update version to 0.13.1 and apply CodingSytemCodeInv to type slices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-05-06 Version 0.13.1
+- `change`: applied the CodingSytemCodeInv directly to .type slices instead of .type to avoid Snapshotting issues in some environments.
+
 ## 2025-04-17 Version 0.13.0
 - `change`: removed KBV_CS_SFHIR_BAR2_WBO_OID_URL (urn:oid:1.2.276.0.76.5.114) as these were replaced by IHE codes several years ago. 
 - `change`: removed KBV_CS_SFHIR_BAR2_WBO_OID_URL (urn:oid:1.2.276.0.76.5.114) from PractitionerQualificationVS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "de.gematik.fhir.directory",
-  "version": "0.11.25",
+  "version": "0.13.1",
   "author": "gematik GmbH",
   "description": "Package Release des gematik FHIR Directory",
   "fhirVersions": [

--- a/src/fhir/fsh-generated/resources/CodeSystem-EndpointDirectoryConnectionType.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-EndpointDirectoryConnectionType.json
@@ -6,7 +6,7 @@
   "id": "EndpointDirectoryConnectionType",
   "title": "Codes for Endpoint.connectionType",
   "description": "CodeSystem TI specific connection types assigned to the Endpoints",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/EndpointDirectoryConnectionType",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-EndpointDirectoryPayloadType.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-EndpointDirectoryPayloadType.json
@@ -6,7 +6,7 @@
   "id": "EndpointDirectoryPayloadType",
   "title": "Codes for Endpoint.payloadType",
   "description": "CodeSystem TI specific payload types assigned to the Endpoints\n\nCodes are maintained by gematik.\nThe codes are used to declare which processes are supported by an entity with the corresponding entry in the gematik Directory.\nNew codes can be requested at gematik. There must exist a specification for each code so that developers can find out how to implement the process.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/EndpointDirectoryPayloadType",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-EndpointVisibilityCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-EndpointVisibilityCS.json
@@ -6,7 +6,7 @@
   "id": "EndpointVisibilityCS",
   "title": "EndpointVisibilityCS",
   "description": "EndpointVisibilityCS",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/EndpointVisibilityCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-HealthcareServiceSpecialtyCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-HealthcareServiceSpecialtyCS.json
@@ -6,7 +6,7 @@
   "id": "HealthcareServiceSpecialtyCS",
   "title": "HealthcareService Specialty",
   "description": "Specialty codes of HealthcareServices",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/HealthcareServiceSpecialtyCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-HolderCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-HolderCS.json
@@ -6,7 +6,7 @@
   "id": "HolderCS",
   "title": "Codes for identity authorities (Holder)",
   "description": "Code System for identity authories in the TI, which verify and control the identities of practitioners and organisations",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/HolderCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-OpeningTimeQualifierCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-OpeningTimeQualifierCS.json
@@ -6,7 +6,7 @@
   "id": "OpeningTimeQualifierCS",
   "title": "OpeningTimeQualifierCS",
   "description": "Qualifier code for HealthCareService opening times",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/OpeningTimeQualifierCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-OrganizationProfessionOID.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-OrganizationProfessionOID.json
@@ -6,7 +6,7 @@
   "id": "OrganizationProfessionOID",
   "title": "CodeSystem for ProfessionOID of Institutions",
   "description": "The codes for Organizations based on Profession OIDs defined in [gemSpec_OID](https://fachportal.gematik.de/fachportal-import/files/gemSpec_OID_V3.10.0.pdf)",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/OrganizationProfessionOID",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-OrganizationProviderType.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-OrganizationProviderType.json
@@ -5,7 +5,7 @@
   "name": "OrganizationProviderType",
   "id": "OrganizationProviderType",
   "description": "CodeSystem of TI Service Provider types as to be found in the gematik Directory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/OrganizationProviderType",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-OrganizationVisibilityCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-OrganizationVisibilityCS.json
@@ -6,7 +6,7 @@
   "id": "OrganizationVisibilityCS",
   "title": "OrganizationVisibilityCS",
   "description": "OrganizationVisibilityCS",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/OrganizationVisibilityCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-Origin.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-Origin.json
@@ -5,7 +5,7 @@
   "name": "Origin",
   "id": "Origin",
   "description": "CodeSystem which identifies the origin of a resource in the FHIR Directory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/Origin",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-PharmacyHealthcareSpecialtyCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-PharmacyHealthcareSpecialtyCS.json
@@ -6,7 +6,7 @@
   "id": "PharmacyHealthcareSpecialtyCS",
   "title": "Pharmacy HealthcareService Specialty",
   "description": "Specialty codes of pharmacy HealthcareServices",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/PharmacyHealthcareSpecialtyCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-PharmacyTypeCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-PharmacyTypeCS.json
@@ -6,7 +6,7 @@
   "id": "PharmacyTypeCS",
   "title": "Pharmacy type",
   "description": "Pharmacy type codes of accessability for patients",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/PharmacyTypeCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-PharmacyTypeLDAPCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-PharmacyTypeLDAPCS.json
@@ -6,7 +6,7 @@
   "id": "PharmacyTypeLDAPCS",
   "title": "Pharmacy type LDAP",
   "description": "Pharmacy type codes used in the LDAP-VZD",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/PharmacyTypeLDAPCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-PractitionerProfessionOID.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-PractitionerProfessionOID.json
@@ -6,7 +6,7 @@
   "id": "PractitionerProfessionOID",
   "title": "CodeSystem for Practitioner's ProfessionOID",
   "description": "The codes for Practitioners based on Profession OIDs defined in [gemSpec_OID](https://fachportal.gematik.de/fachportal-import/files/gemSpec_OID_V3.10.0.pdf)",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/PractitionerProfessionOID",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-Region.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-Region.json
@@ -6,7 +6,7 @@
   "id": "Region",
   "title": "Codes for regions in german healthcare system.",
   "description": "Additionally to german Bundeslander there are 2 sub-provinces \n`Nordrhein` and `Westfalen-Lippe`.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/Region",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-VZDHealthCareServiceCharacteristicsCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-VZDHealthCareServiceCharacteristicsCS.json
@@ -5,7 +5,7 @@
   "name": "VZDHealthCareServiceCharacteristicsCS",
   "id": "VZDHealthCareServiceCharacteristicsCS",
   "description": "CodeSystem of VZD specific HealthcareService characteristics",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/VZDHealthCareServiceCharacteristicsCS",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-aerztlicheBerufsvarianten.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-aerztlicheBerufsvarianten.json
@@ -6,7 +6,7 @@
   "id": "aerztlicheBerufsvarianten",
   "title": "AerztlicheBerufsvarianten",
   "description": "AerztlicheBerufsvarianten",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "urn:oid:1.2.276.0.76.5.493",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-physicalFeatures.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-physicalFeatures.json
@@ -5,7 +5,7 @@
   "name": "PhysicalFeaturesHealthCareServiceCS",
   "id": "physicalFeatures",
   "description": "CodeSystem of defined physical features",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/CodeSystem/physicalFeatures",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/CodeSystem-zahnaerztliche-fachrichtungen-oid-url.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-zahnaerztliche-fachrichtungen-oid-url.json
@@ -6,7 +6,7 @@
   "id": "zahnaerztliche-fachrichtungen-oid-url",
   "title": "ZahnaerztlicheFachrichtungen",
   "description": "ZahnaerztlicheFachrichtungen",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "urn:oid:1.2.276.0.76.5.494",
   "concept": [
     {

--- a/src/fhir/fsh-generated/resources/SearchParameter-EndpointAddressSP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-EndpointAddressSP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "EndpointAddressSP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/EndpointAddressSP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-EndpointVisibilitySP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-EndpointVisibilitySP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "EndpointVisibilitySP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/EndpointVisibilitySP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-HealthcareServiceCoverageAreaPostalCodeSP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-HealthcareServiceCoverageAreaPostalCodeSP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "HealthcareServiceCoverageAreaPostalCodeSP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/HealthcareServiceCoverageAreaPostalCodeSP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-HolderIdSP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-HolderIdSP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "HolderIdSP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/HolderIdSP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-OrganizationAliasSP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-OrganizationAliasSP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "OrganizationAliasSP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/OrganizationAliasSP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-OrganizationNCPeHCountrySP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-OrganizationNCPeHCountrySP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "OrganizationNCPeHCountrySP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/OrganizationNCPeHCountrySP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-OrganizationTypeDisplaySP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-OrganizationTypeDisplaySP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "OrganizationTypeDisplaySP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/OrganizationTypeDisplaySP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-OrganizationVisibilitySP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-OrganizationVisibilitySP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "OrganizationVisibilitySP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/OrganizationVisibilitySP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-OwnerTelematikIdSP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-OwnerTelematikIdSP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "OwnerTelematikIdSP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/OwnerTelematikIdSP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/SearchParameter-PractitionerQualificationSP.json
+++ b/src/fhir/fsh-generated/resources/SearchParameter-PractitionerQualificationSP.json
@@ -2,7 +2,7 @@
   "resourceType": "SearchParameter",
   "id": "PractitionerQualificationSP",
   "url": "https://gematik.de/fhir/directory/SearchParameter/PractitionerQualificationSP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "status": "active",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-CodingWithCodeAndSystem.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-CodingWithCodeAndSystem.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingWithCodeAndSystem",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/CodingWithCodeAndSystem",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "CodingWithCodeAndSystem",
   "title": "Coding with code and system",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-EndpointDirectory.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-EndpointDirectory.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "EndpointDirectory",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/EndpointDirectory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "EndpointDirectory",
   "title": "Endpoint in gematik Directory",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-EndpointVisibility.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-EndpointVisibility.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "EndpointVisibility",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/EndpointVisibility",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "EndpointVisibility",
   "title": "EndpointVisibility",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-HealthcareServiceDirectory.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-HealthcareServiceDirectory.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "HealthcareServiceDirectory",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/HealthcareServiceDirectory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "HealthcareServiceDirectory",
   "title": "HealthcareService in gematik Directory",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-HealthcareServiceDirectoryStrict.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-HealthcareServiceDirectoryStrict.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "HealthcareServiceDirectoryStrict",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/HealthcareServiceDirectoryStrict",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "HealthcareServiceDirectoryStrict",
   "title": "HealthcareServiceDirectoryStrict",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-LocationDirectory.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-LocationDirectory.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "LocationDirectory",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/LocationDirectory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "LocationDirectory",
   "title": "Location in gematik Directory",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-LocationDirectoryStrict.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-LocationDirectoryStrict.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "LocationDirectoryStrict",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/LocationDirectoryStrict",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "LocationDirectoryStrict",
   "title": "LocationDirectoryStrict",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-OrganizationDirectory.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-OrganizationDirectory.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "OrganizationDirectory",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "OrganizationDirectory",
   "title": "Organization in gematik Directory",
   "status": "active",
@@ -197,19 +197,6 @@
         "mustSupport": true
       },
       {
-        "id": "Organization.type.coding",
-        "path": "Organization.type.coding",
-        "constraint": [
-          {
-            "key": "CodingSytemCodeInv",
-            "severity": "warning",
-            "human": "System and Code SHOULD be present",
-            "expression": "system.exists() and code.exists()",
-            "source": "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
-          }
-        ]
-      },
-      {
         "id": "Organization.type:providerType",
         "path": "Organization.type",
         "sliceName": "providerType",
@@ -222,6 +209,19 @@
         }
       },
       {
+        "id": "Organization.type:providerType.coding",
+        "path": "Organization.type.coding",
+        "constraint": [
+          {
+            "key": "CodingSytemCodeInv",
+            "severity": "warning",
+            "human": "System and Code SHOULD be present",
+            "expression": "system.exists() and code.exists()",
+            "source": "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+          }
+        ]
+      },
+      {
         "id": "Organization.type:profession",
         "path": "Organization.type",
         "sliceName": "profession",
@@ -232,6 +232,19 @@
           "strength": "required",
           "valueSet": "https://gematik.de/fhir/directory/ValueSet/OrganizationProfessionOIDTypeVS"
         }
+      },
+      {
+        "id": "Organization.type:profession.coding",
+        "path": "Organization.type.coding",
+        "constraint": [
+          {
+            "key": "CodingSytemCodeInv",
+            "severity": "warning",
+            "human": "System and Code SHOULD be present",
+            "expression": "system.exists() and code.exists()",
+            "source": "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectory"
+          }
+        ]
       },
       {
         "id": "Organization.name",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-OrganizationDirectoryStrict.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-OrganizationDirectoryStrict.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "OrganizationDirectoryStrict",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/OrganizationDirectoryStrict",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "OrganizationDirectoryStrict",
   "title": "OrganizationDirectoryStrict",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-OrganizationVisibility.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-OrganizationVisibility.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "OrganizationVisibility",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/OrganizationVisibility",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "OrganizationVisibility",
   "title": "OrganizationVisibility",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-OwnerTelematikIdEx.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-OwnerTelematikIdEx.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "OwnerTelematikIdEx",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/OwnerTelematikIdEx",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "OwnerTelematikIdEx",
   "title": "OwnerTelematikIdEx",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-PhysicalFeaturesAdditionalNoteEX.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-PhysicalFeaturesAdditionalNoteEX.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "PhysicalFeaturesAdditionalNoteEX",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/PhysicalFeaturesAdditionalNoteEX",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "PhysicalFeaturesAdditionalNoteEX",
   "title": "Physical Features Additional Note",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerDirectory.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerDirectory.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "PractitionerDirectory",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "PractitionerDirectory",
   "title": "Practitioner in gematik Directory",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerDirectoryStrict.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerDirectoryStrict.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "PractitionerDirectoryStrict",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/PractitionerDirectoryStrict",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "PractitionerDirectoryStrict",
   "title": "PractitionerDirectoryStrict",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerRoleDirectory.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerRoleDirectory.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "PractitionerRoleDirectory",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/PractitionerRoleDirectory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "PractitionerRoleDirectory",
   "title": "PractitionerRole in gematik Directory",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerRoleDirectoryStrict.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-PractitionerRoleDirectoryStrict.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "PractitionerRoleDirectoryStrict",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/PractitionerRoleDirectoryStrict",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "PractitionerRoleDirectoryStrict",
   "title": "PractitionerRoleDirectoryStrict",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-ServiceCoverageArea.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-ServiceCoverageArea.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ServiceCoverageArea",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/ServiceCoverageArea",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "ServiceCoverageArea",
   "title": "ServiceCoverageArea",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-ServiceCoveragePostalCode.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-ServiceCoveragePostalCode.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ServiceCoveragePostalCode",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/ServiceCoveragePostalCode",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "ServiceCoveragePostalCode",
   "title": "ServiceCoveragePostalCode",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-SpecialOpeningTimesEX.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-SpecialOpeningTimesEX.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "SpecialOpeningTimesEX",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/SpecialOpeningTimesEX",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "SpecialOpeningTimesEX",
   "title": "SpecialOpeningTimesEX",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-endpoint-directory-Strict.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-endpoint-directory-Strict.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "endpoint-directory-Strict",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/endpoint-directory-Strict",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "EndpointDirectoryStrict",
   "title": "EndpointDirectory-Strict",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-holder-id-ex.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-holder-id-ex.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "holder-id-ex",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/holder-id-ex",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "HolderIdEx",
   "title": "Holder ID Extension",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-ncpeh-country-ex.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-ncpeh-country-ex.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ncpeh-country-ex",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/ncpeh-country-ex",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "NCPeHCountryEx",
   "title": "National Contact Point of Health (NCPeH) Country Extension",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-results-filtered-ex.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-results-filtered-ex.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "results-filtered-ex",
   "url": "https://gematik.de/fhir/directory/StructureDefinition/results-filtered-ex",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "name": "ResultsFilteredEx",
   "title": "Results Filtered Extension",
   "status": "active",

--- a/src/fhir/fsh-generated/resources/ValueSet-AddressStateVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-AddressStateVS.json
@@ -4,7 +4,7 @@
   "name": "AddressStateVS",
   "id": "AddressStateVS",
   "description": "ValueSet for `Address.state`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/AddressStateVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-EndpointConnectionTypeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-EndpointConnectionTypeVS.json
@@ -4,7 +4,7 @@
   "name": "EndpointConnectionTypeVS",
   "id": "EndpointConnectionTypeVS",
   "description": "ValueSet for `Endpoint.connectionType`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/EndpointConnectionTypeVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-EndpointPayloadTypeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-EndpointPayloadTypeVS.json
@@ -4,7 +4,7 @@
   "name": "EndpointPayloadTypeVS",
   "id": "EndpointPayloadTypeVS",
   "description": "ValueSet for `Endpoint.payloadType`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/EndpointPayloadTypeVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-EndpointVisibilityVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-EndpointVisibilityVS.json
@@ -5,7 +5,7 @@
   "id": "EndpointVisibilityVS",
   "title": "EndpointVisibilityVS",
   "description": "EndpointVisibilityVS",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/EndpointVisibilityVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-HealthcareServiceTypeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-HealthcareServiceTypeVS.json
@@ -4,7 +4,7 @@
   "name": "HealthcareServiceTypeVS",
   "id": "HealthcareServiceTypeVS",
   "description": "ValueSet for `HealthcareService.type`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/HealthcareServiceTypeVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-HealthcareSpecialtyTypeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-HealthcareSpecialtyTypeVS.json
@@ -5,7 +5,7 @@
   "id": "HealthcareSpecialtyTypeVS",
   "title": "ValueSet of HealthcareService specialities",
   "description": "HealthcareService specialities",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/HealthcareSpecialtyTypeVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-OpeningTimeQualifierVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-OpeningTimeQualifierVS.json
@@ -5,7 +5,7 @@
   "id": "OpeningTimeQualifierVS",
   "title": "OpeningTimeQualifierVS",
   "description": "ValueSet of Qualifier codes for HealthCareService opening times",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/OpeningTimeQualifierVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-OrganizationProfessionOIDTypeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-OrganizationProfessionOIDTypeVS.json
@@ -4,7 +4,7 @@
   "name": "OrganizationProfessionOIDTypeVS",
   "id": "OrganizationProfessionOIDTypeVS",
   "description": "ValueSet for `Organization.type`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/OrganizationProfessionOIDTypeVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-OrganizationTypeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-OrganizationTypeVS.json
@@ -4,7 +4,7 @@
   "name": "OrganizationTypeVS",
   "id": "OrganizationTypeVS",
   "description": "ValueSet for `Organization.type`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/OrganizationTypeVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-OrganizationVisibilityVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-OrganizationVisibilityVS.json
@@ -5,7 +5,7 @@
   "id": "OrganizationVisibilityVS",
   "title": "OrganizationVisibilityVS",
   "description": "OrganizationVisibilityVS",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/OrganizationVisibilityVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-OriginVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-OriginVS.json
@@ -4,7 +4,7 @@
   "name": "OriginVS",
   "id": "OriginVS",
   "description": "ValueSet for `meta.tag[Origin]`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/OriginVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-PhysicalFeaturesHealthCareServiceVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-PhysicalFeaturesHealthCareServiceVS.json
@@ -4,7 +4,7 @@
   "name": "PhysicalFeaturesHealthCareServiceVS",
   "id": "PhysicalFeaturesHealthCareServiceVS",
   "description": "ValueSet of defined physical features",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/PhysicalFeaturesHealthCareServiceVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-PractitionerQualificationVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-PractitionerQualificationVS.json
@@ -4,7 +4,7 @@
   "name": "PractitionerQualificationVS",
   "id": "PractitionerQualificationVS",
   "description": "ValueSet for `Practitoner.qualification`",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/PractitionerQualificationVS",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-healthcare-service-category-codes.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-healthcare-service-category-codes.json
@@ -5,7 +5,7 @@
   "id": "healthcare-service-category-codes",
   "title": "HealthcareService Category Codes",
   "description": "Codes for the VZD HealthcareService category element.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/healthcare-service-category-codes",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-healthcareservice-technical-characteristic-vs.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-healthcareservice-technical-characteristic-vs.json
@@ -5,7 +5,7 @@
   "id": "healthcareservice-technical-characteristic-vs",
   "title": "HealthCareServiceTechnicalCharacteristicVS",
   "description": "HealthCareServiceTechnicalCharacteristicVS",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/healthcareservice-technical-characteristic-vs",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/fsh-generated/resources/ValueSet-ncpeh-healthcare-service-speciality-cs.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-ncpeh-healthcare-service-speciality-cs.json
@@ -5,7 +5,7 @@
   "id": "ncpeh-healthcare-service-speciality-cs",
   "title": "NCPeH HealthcareService Speciality ValueSet",
   "description": "Supported documents by a National Contact Point",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "url": "https://gematik.de/fhir/directory/ValueSet/ncpeh-healthcare-service-speciality-cs",
   "experimental": false,
   "publisher": "gematik GmbH",

--- a/src/fhir/input/fsh/profiles/OrganizationDirectory.fsh
+++ b/src/fhir/input/fsh/profiles/OrganizationDirectory.fsh
@@ -36,12 +36,13 @@ organisations specific for german Healthcare and Telematics Infrastructure.
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
-* type.coding obeys CodingSytemCodeInv
 * type contains
     providerType 0..* MS and
     profession 0..* MS
 * type[providerType] from OrganizationTypeVS
+  * coding obeys CodingSytemCodeInv
 * type[profession] from OrganizationProfessionOIDTypeVS
+  * coding obeys CodingSytemCodeInv
 * name 1..1 MS
 * alias MS
 * contact MS

--- a/src/fhir/input/fsh/ruleset.fsh
+++ b/src/fhir/input/fsh/ruleset.fsh
@@ -1,4 +1,4 @@
-Alias: $version = 0.13.0
+Alias: $version = 0.13.1
 
 RuleSet: Meta
 * ^status = #active


### PR DESCRIPTION
## 2025-05-06 Version 0.13.1
- `change`: applied the CodingSytemCodeInv directly to .type slices instead of .type to avoid Snapshotting issues in some environments.