### PR TITLE
Fix naming of timProvider field

### DIFF
--- a/src/openapi/I_VZD_TIM_Provider_Services.yaml
+++ b/src/openapi/I_VZD_TIM_Provider_Services.yaml
@@ -3,7 +3,11 @@ info:
   title: I_VZD_TIM_Provider_Services
   description: REST interface to retrieve the TI-Messenger federation list and to administrate the TI-Messenger domains.
 
-  version: 1.3.9
+  version: 1.4.0
+
+    # Version 1.4.0
+    #   - Corrected "timProvider" field name
+    #               timProvider -> timAnbieter
 
     # Version 1.3.9
     #   - Corrected "mxid" format description in "whereIs" operation
@@ -543,7 +547,7 @@ components:
           minItems: 1
           uniqueItems: true
           example: [ 108433248, 104127692 ]
-        timProvider:
+        timAnbieter:
           description: The Zuweisungsgruppe im TI-ITSM-System of the TI-Messenger Provider, who added the domain
           type: string
           readOnly: true


### PR DESCRIPTION
The field appears to be called `timAnbieter` in the implementation. The spec was fixed accordingly in version 1.6.0 but the schema here still uses the wrong name.