### PR TITLE
Update fdv-relevant oid-list

### DIFF
--- a/docs/FHIR_VZD_HOWTO_Search.adoc
+++ b/docs/FHIR_VZD_HOWTO_Search.adoc
@@ -930,7 +930,11 @@ Incoming search requests containing these ProfessionOIDs (excluding Diga) are au
 |1.2.276.0.76.4.255 |x |x |Kassenärztliche Vereinigung
 |1.2.276.0.76.4.256 |x |x |Kassenzahnärztliche Vereinigung
 |1.2.276.0.76.4.257 |x |x |Krankenhausgesellschaft
-|1.2.276.0.76.4.282 |x | |DIGA (Digital Health Application)
+|1.2.276.0.76.4.282 |x |x |DIGA (Digital Health Application)
+|1.2.276.0.76.4.278 |x |x |Ergotherapiepraxis
+|1.2.276.0.76.4.279 |x |x |Logopaedische Praxis
+|1.2.276.0.76.4.280 |x |x |Podologiepraxis
+|1.2.276.0.76.4.281 |x |x |Ernährungstherapeutische Praxis
 |===
 
 Note: The OID for representative roles (oid_versicherter) is currently not available and cannot be mapped.


### PR DESCRIPTION
This pull request updates the documentation for incoming search requests by expanding the list of supported ProfessionOIDs and correcting the entry for Digital Health Applications (DIGA). The main changes focus on improving the completeness and accuracy of the ProfessionOID table.

Updates to ProfessionOID documentation:

* Marked `DIGA (Digital Health Application)` (OID: 1.2.276.0.76.4.282) as supported in the table, correcting its previous status.
* Added new entries for `Ergotherapiepraxis`, `Logopaedische Praxis`, `Podologiepraxis`, and `Ernährungstherapeutische Praxis` with their respective OIDs, all marked as supported.