### PR TITLE
Update I_FHIR_VZD_Certificates.yaml

### DIFF
--- a/src/openapi/I_FHIR_VZD_Certificates.yaml
+++ b/src/openapi/I_FHIR_VZD_Certificates.yaml
@@ -2,7 +2,10 @@ openapi: 3.0.1
 info:
   title: I_FHIR_VZD_Certificates
   description: REST Schnittstelle zum Abruf von Zertifikaten.
-  version: 0.1.4
+  version: 0.1.5
+  # Änderungen in Version 0.1.5
+  #   - Suchparameter um ldapUid ergänzt
+  #
   # Änderungen in Version 0.1.4
   #   - Keine Treffer führen zur leeren Liste statt 404
   #
@@ -107,6 +110,11 @@ paths:
         - name: publicKeyAlgorithm
           in: query
           description: Erlaubt die Suche mit Hilfe des Attributs publicKeyAlgorithm.
+          schema:
+            type: string
+        - name: ldapUid
+          in: query
+          description: Erlaubt die Suche mit Hilfe der ldapUid.
           schema:
             type: string
       responses:


### PR DESCRIPTION
This pull request updates the OpenAPI specification for the `I_FHIR_VZD_Certificates` service, introducing a new search parameter and incrementing the API version. The main changes are:

API enhancements:

* Added a new query parameter `ldapUid` to allow searching for certificates using the `ldapUid` attribute.

Documentation updates:

* Bumped the API version from `0.1.4` to `0.1.5` and documented the addition of the `ldapUid` search parameter in the changelog section.