### PR TITLE
Update I_FHIR_VZD_Certificates.yaml

### DIFF
--- a/src/openapi/I_FHIR_VZD_Certificates.yaml
+++ b/src/openapi/I_FHIR_VZD_Certificates.yaml
@@ -4,7 +4,7 @@ info:
   description: REST Schnittstelle zum Abruf von Zertifikaten.
   version: 0.1.5
   # Änderungen in Version 0.1.5
-  #   - Suchparameter um ldapUid ergänzt
+  #   - Suchparameter und Rückgabe um ldapUid ergänzt
   #
   # Änderungen in Version 0.1.4
   #   - Keine Treffer führen zur leeren Liste statt 404
@@ -154,6 +154,9 @@ components:
           type: string
           description: 'Wird beim Anlegen des Eintrags vom VZD aus dem Zertifikat 
                         übernommen (Feld registrationNumber der Extension Admission).'
+        ldapUid:
+          type: string
+          description: 'ldapUid des Quellsystem.'
         userCertificate:
           type: string
           description: 'Zertifikat im DER Format. Base64 kodiert.'


### PR DESCRIPTION
This pull request makes a minor update to the OpenAPI specification for the certificate retrieval interface. The main change is the addition of the `ldapUid` field as both a search parameter and a returned attribute in the API.

Specification updates:

* Added `ldapUid` as a new string property to the response object, with a description indicating it is the ldapUid from the source system.
* Updated the version 0.1.5 changelog comment to clarify that both the search parameters and the returned data now include `ldapUid`.