### PR TITLE
Remove error 423

### DIFF
--- a/src/openapi/DirectoryApplicationMaintenance.yaml
+++ b/src/openapi/DirectoryApplicationMaintenance.yaml
@@ -6,8 +6,11 @@ info:
    # REST Schnittstelle zur Pflege der Fachanwendungsdaten der Verzeichniseinträge
      Über diese Schnittstelle können Fachanwendungsdaten der Verzeichniseinträge erzeugt, aktualisiert und gelöscht werden. 
 
-  version: 1.4.8
+  version: 1.4.9
 
+  # Änderungen in Version 1.4.9
+  #  423-Fehler (Locked) für Änderungen an inaktiven Einträgen entfernt
+  #
   # Änderungen in Version 1.4.8
   #  423-Fehler (Locked) für Änderungen an inaktiven Einträgen ergänzt
   #
@@ -627,13 +630,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'        
-        423:
-          description: Locked
-          #  entry.active = false
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
 
   /DirectoryEntries/{telematikID}/KOM-LE_Fachdaten/{fad}:
   
@@ -772,13 +768,6 @@ paths:
         404:
           description: Not Found
                     #  telematikID not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        423:
-          description: Locked
-          #  entry.active = false
           content:
             application/json:
               schema:


### PR DESCRIPTION
This pull request updates the OpenAPI specification in `DirectoryApplicationMaintenance.yaml` to remove the 423 Locked error response for changes to inactive directory entries. This change reflects a policy update: previously, attempts to modify inactive entries would return a 423 error, but this is no longer the case.

**OpenAPI Specification Updates:**

* The API version in the `info` section is incremented from `1.4.8` to `1.4.9`, and the changelog notes that the 423 error for inactive entries has been removed.
* All 423 Locked error response definitions related to modifying inactive entries are removed from the relevant endpoints, so the API no longer documents this error case. [[1]](diffhunk://#diff-dc521b4e36f672cae044a38ceb20a9ee9308d39aff69cf78e1dfbb2863630d5aL630-L636) [[2]](diffhunk://#diff-dc521b4e36f672cae044a38ceb20a9ee9308d39aff69cf78e1dfbb2863630d5aL779-L785)