### PR TITLE
Add optional parameter specialty and characteristics to near-searches

### DIFF
--- a/docs/FHIR_VZD_HOWTO_Search.adoc
+++ b/docs/FHIR_VZD_HOWTO_Search.adoc
@@ -958,8 +958,13 @@ Search for all organizations in the specified radius, sorted by distance, filter
 - filtering entries outside opening hours if they are stored in HealthcareServices. When comparing opening times defined with the target time defined by the current time and the target time defined by the "isOpenInMinutes" parameter, a configurable tolerance (default value: 1 min) is used to compensate for query and display latencies,
 - filtering for active and visible organizations,
 - filtering for Organisationen of type "https://gematik.de/fhir/directory/CodeSystem/OrganizationProfessionOID|1.2.276.0.76.4.54" (pharmacy)
+- filtering by specialty code(s) when one or more specialty parameters are provided,
+- filtering by characteristics code(s) when one or more characteristics parameters are provided,
 - the search result is reduced to the number of organizations, defined in the "_count" parameter. The number of hits defined by the _count parameter is limited to 1 or 100 if it is outside this range,
 - the search result lists the linked resources Organization, HealthcareService and Location.
+
+For specialty and characteristics, repeated usage of the same parameter is supported and combined with AND logic.
+Both parameters are provided as free-text input, but must contain valid codes from the relevant coding systems (for example `10`, `20`, `impfung`). Unknown values lead to no hits.
 
 
 .Table Pharmacy radius search parameters
@@ -990,6 +995,14 @@ Search for all organizations in the specified radius, sorted by distance, filter
 |Only entries that indicate opening times that are open in x minutes AND that have not maintained opening times. 0 can be delivered to receive the current opened organizations/pharmacies.
 |int   
 
+|*specialty* (optional)
+|Code filter for specialty. The parameter can be used multiple times; all specified values are combined with AND logic.
+|String
+
+|*characteristics* (optional)
+|Code filter for characteristics. The parameter can be used multiple times; all specified values are combined with AND logic.
+|String
+
 |*_count* (optional)
 |Desired number of search results.
 |int   
@@ -1009,6 +1022,9 @@ GET {{fhir_server}}/fdv/search/HealthcareService?_query=nearPharmacy
     &distance=10
     &_count=8
     &text=Botendienst
+    &specialty=10
+    &specialty=20
+    &characteristics=parkmoeglichkeit
 ----
 
 
@@ -1028,8 +1044,13 @@ Search for all organizations in the specified radius, sorted by distance, filter
 - filtering entries outside opening hours if they are stored in HealthcareServices. When comparing opening times defined with the target time defined by the current time and the target time defined by the "isOpenInMinutes" parameter, a configurable tolerance (default value: 1 min) is used to compensate for query and display latencies,
 - filtering for active and visible organizations,
 - filtering for organizations of specified type (see search parameter "organization.type"),
+- filtering by specialty code(s) when one or more specialty parameters are provided,
+- filtering by characteristics code(s) when one or more characteristics parameters are provided,
 - the search result is reduced to the number of organizations, defined in the "_count" parameter. The number of hits defined by the _count parameter is limited to 1 or 100 if it is outside this range,
 - the search result lists the linked resources Organization, HealthcareService and Location.
+
+For specialty and characteristics, repeated usage of the same parameter is supported and combined with AND logic.
+Both parameters are provided as free-text input, but must contain valid codes from the relevant coding systems (for example `10`, `20`, `impfung`). Unknown values lead to no findings.
 
 
 .Table Organization radius search parameters
@@ -1060,6 +1081,14 @@ Search for all organizations in the specified radius, sorted by distance, filter
 |Only entries that indicate opening times that are open in x minutes AND that have not maintained opening times. 0 can be delivered to receive the current opened organizations/pharmacies.
 |int   
 
+|*specialty* (optional)
+|Code filter for specialty. The parameter can be used multiple times; all specified values are combined with AND logic.
+|String
+
+|*characteristics* (optional)
+|Code filter for characteristics. The parameter can be used multiple times; all specified values are combined with AND logic.
+|String
+
 |*_count* (optional)
 |Desired number of search results.
 |int   
@@ -1083,5 +1112,8 @@ GET {{fhir_server}}/fdv/search/HealthcareService?_query=near
     &distance=10
     &_count=8
     &organization.type=1.2.276.0.76.4.50
+    &specialty=10
+    &specialty=20
+    &characteristics=parkmoeglichkeit
 ----
 


### PR DESCRIPTION
This pull request updates the FHIR VZD search documentation to describe new filtering capabilities for organization and pharmacy radius searches. The main changes introduce support for filtering search results by specialty and characteristics codes, including details on parameter usage and updated example queries.

**Enhancements to search filtering:**

* Added support for filtering organizations and pharmacies by specialty codes and characteristics codes in radius search queries. These parameters can be specified multiple times and are combined using AND logic. [[1]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R961-R968) [[2]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R1047-R1054)
* Clarified that specialty and characteristics parameters must contain valid codes; unknown values will yield no results. [[1]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R961-R968) [[2]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R1047-R1054)

**Documentation updates:**

* Updated parameter tables to include the new `specialty` and `characteristics` parameters, specifying their usage, type, and logic. [[1]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R998-R1005) [[2]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R1084-R1091)
* Added example queries demonstrating the use of the new parameters in both pharmacy and general organization radius searches. [[1]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R1025-R1027) [[2]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R1115-R1117)