### PR TITLE
Add runtime hints for additional optional parameters in near searches

### DIFF
--- a/docs/FHIR_VZD_HOWTO_Search.adoc
+++ b/docs/FHIR_VZD_HOWTO_Search.adoc
@@ -18,7 +18,7 @@ image::gematik_logo.svg[gematik,float="right"]
 
 [width="100%",cols="50%,50%",options="header",]
 |===
-|Version: |1.1.9
+|Version: |1.1.10
 |Referencing: |gemILF_FHIR_VZD
 |===
 
@@ -78,6 +78,10 @@ Added custom Search Parameters
 
 |1.1.9 |04.06.26 | 5. FHIR Operations - FHIR VZD endpoint /fdv/search
 |Add optional parameter specialty and characteristics to near-searches 
+  |gematik
+
+|1.1.10 |29.06.26 | 5. FHIR Operations - FHIR VZD endpoint /fdv/search
+|Add runtime hints for additional optional parameters in near searches
   |gematik
 
 
@@ -984,6 +988,21 @@ Search for all organizations in the specified radius, sorted by distance, filter
 For specialty and characteristics, repeated usage of the same parameter is supported and combined with AND logic.
 Both parameters are provided as free-text input, but must contain valid codes from the relevant coding systems (for example `10`, `20`, `impfung`). Unknown values lead to no hits.
 
+[NOTE]
+--
+Using additional optional parameters such as `specialty` and `characteristics` increases search complexity and can increase runtime. Depending on radius, combined filters, and additional parameters such as `text` and `isOpenInMinutes`, response times of several seconds are possible.
+
+Observed examples:
+
+- Around 2-3 seconds:
+  `./fdv/search/HealthcareService?_query=near&latitude=47.9147&longitude=12.7191&distance=1&specialty=10`
+- Around 5-6 seconds:
+  `./fdv/search/HealthcareService?_query=nearPharmacy&latitude=47.9147&longitude=12.7191&distance=100&specialty=10&specialty=30&isOpenInMinutes=7322&text=Apo`
+- In rare cases, runtimes up to around 8 seconds were observed.
+
+Runtime behavior should be reviewed by implementing party.
+--
+
 
 .Table Pharmacy radius search parameters
 |===
@@ -1070,6 +1089,21 @@ Search for all organizations in the specified radius, sorted by distance, filter
 For specialty and characteristics, repeated usage of the same parameter is supported and combined with AND logic.
 Both parameters are provided as free-text input, but must contain valid codes from the relevant coding systems (for example `10`, `20`, `impfung`). Unknown values lead to no findings.
 
+[NOTE]
+--
+Using additional optional parameters such as `specialty` and `characteristics` increases search complexity and can increase runtime. Depending on radius, combined filters, and additional parameters such as `text` and `isOpenInMinutes`, response times of several seconds are possible.
+
+Observed examples:
+
+- Around 2-3 seconds:
+  `./ti-fhir-provider/fdv/search/HealthcareService?_query=near&latitude=47.9147&longitude=12.7191&distance=1&specialty=10`
+- Around 5-6 seconds:
+  `./ti-fhir-provider/fdv/search/HealthcareService?_query=nearPharmacy&latitude=47.9147&longitude=12.7191&distance=100&specialty=10&specialty=30&isOpenInMinutes=7322&text=Apo`
+- In rare cases, runtimes up to around 8 seconds were observed.
+
+Runtime behavior should be reviewed by implementing party.
+--
+
 
 .Table Organization radius search parameters
 |===
@@ -1134,4 +1168,3 @@ GET {{fhir_server}}/fdv/search/HealthcareService?_query=near
     &specialty=20
     &characteristics=parkmoeglichkeit
 ----
-


### PR DESCRIPTION
This pull request updates the FHIR VZD search documentation to version 1.1.10, introducing new runtime hints for optional search parameters and providing guidance on expected response times when using advanced filters. The main focus is on informing users about the potential performance impact when using parameters like `specialty` and `characteristics` in near-search queries.

Documentation updates:

* Increased the documented version to 1.1.10 in `FHIR_VZD_HOWTO_Search.adoc`.
* Added a changelog entry for version 1.1.10, noting the addition of runtime hints for optional parameters in near searches.

Guidance on search performance:

* Added notes explaining that using additional optional parameters (e.g., `specialty`, `characteristics`, `text`, `isOpenInMinutes`) can significantly increase search response times, with observed examples and recommendations for implementers to review runtime behavior. [[1]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R991-R1005) [[2]](diffhunk://#diff-f300da0d00463b1f07677c90baa8682373d3704757ec59c56b9729c5388b87d3R1092-R1106)